### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Official ModelContextProtocol (MCP) server for [Magic UI](https://magicui.design/).
 
+<a href="https://glama.ai/mcp/servers/@magicuidesign/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@magicuidesign/mcp/badge" alt="Magic UI Server MCP server" />
+</a>
+
 ## Install MCP configuration
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [Magic UI MCP Server](https://glama.ai/mcp/servers/@magicuidesign/mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@magicuidesign/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@magicuidesign/mcp/badge" alt="Magic UI Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.