### PR TITLE
添加 Glama MCP 服務器徽章並修復文件末尾換行問題

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Official ModelContextProtocol (MCP) server for [Magic UI](https://magicui.design/).
 
+<a href="https://glama.ai/mcp/servers/@magicuidesign/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@magicuidesign/mcp/badge" alt="Magic UI Server MCP server" />
+</a>
+
 <div align="center">
   <img src="https://github.com/magicuidesign/mcp/blob/main/public/mcp.png" alt="MCP" />
 </div>


### PR DESCRIPTION
這個 PR 添加了 Glama MCP 服務器徽章，並修復了 README.md 文件末尾的換行問題。

<a href="https://glama.ai/mcp/servers/@magicuidesign/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@magicuidesign/mcp/badge" alt="Magic UI Server MCP server" />
</a>

Glama 定期進行代碼庫和文檔檢查，以：

* 確認 MCP 服務器按預期工作
* 確認服務器的依賴項沒有明顯的安全問題
* 提取服務器特性，如工具、資源、提示和所需參數

這個徽章幫助用戶快速評估 MCP 服務器的安全性、功能和安裝說明。

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author