### PR TITLE
docs: use CLI-safe MCP alias in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add to your IDE's MCP config:
 ```json
 {
   "mcpServers": {
-    "@magicuidesign/mcp": {
+    "magicuidesign-mcp": {
       "command": "npx",
       "args": ["-y", "@magicuidesign/mcp@latest"]
     }


### PR DESCRIPTION
closed https://github.com/magicuidesign/magicui/issues/844
## Description

This PR updates the README MCP configuration example to use a CLI-safe alias for the server name so it works correctly with Claude Code and other MCP clients.

---

## Changes

- Renamed the `mcpServers` key in the README example from `@magicuidesign/mcp` to `magicuidesign-mcp`, while keeping the `command` and `args` (npm package name) unchanged.

---

## Motivation

- Claude Code rejects `@magicuidesign/mcp` as an invalid MCP server name (`Names can only contain letters, numbers, hyphens, and underscores`).
- Using a simple alias like `magicuidesign-mcp` follows common MCP naming conventions and improves compatibility across different clients.
- According to the official Claude tool documentation (“[How to implement tool use](https://platform.claude.com/docs/en/agents-and-tools/tool-use/implement-tool-use)”), the tool `name` must match the regex `^[a-zA-Z0-9_-]{1,64}$`, which is incompatible with a scoped name like `@magicuidesign/mcp`.