### PR TITLE
refactor: enchance code and types

### DIFF
--- a/src/domain/registry.ts
+++ b/src/domain/registry.ts
@@ -11,10 +11,13 @@ export type RegistryExample = z.infer<typeof ExampleComponentSchema>;
 export type RegistryExampleDetail = z.infer<typeof ExampleDetailSchema>;
 export type RegistryItemDetail = z.infer<typeof RegistryItemDetailSchema>;
 
-export type RegistryCatalogItem = {
+type RegistryCatalogItemBase = {
   name: string;
   title: string;
   description?: string;
+}
+
+export type RegistryCatalogItem = RegistryCatalogItemBase & {
   kind: string;
   registryType: string;
 };
@@ -28,10 +31,7 @@ export type RegistryCatalogItemDetail = RegistryCatalogItem & {
   registryDependencies: string[];
   relatedItems?: RegistryCatalogItem[];
   source?: string;
-  examples?: Array<{
-    name: string;
-    title: string;
-    description?: string;
+  examples?: Array<RegistryCatalogItemBase & {
     content: string;
   }>;
 };

--- a/src/services/registry-service.ts
+++ b/src/services/registry-service.ts
@@ -12,7 +12,22 @@ import {
   fetchRegistryItemDetails,
   parseExampleComponents,
 } from "../registry/client.js";
-import { formatComponentName, formatDisplayName } from "../utils/formatters.js";
+import {
+  formatComponentName,
+  formatDisplayName,
+  formatSearchString,
+} from "../utils/formatters.js";
+import type {
+  BuildFilesSourceOptions,
+  FilterCatalogParams,
+  GetRegistryItemOptions,
+  ListRegistryItemsParams,
+  ListRegistryItemsResult,
+  PaginateItemsParams,
+  PaginateItemsResult,
+  SearchRegistryItemsParams,
+  SearchRegistryItemsResult,
+} from "./types.js";
 
 const DEFAULT_RESULT_LIMIT = 25;
 const MAX_RESULT_LIMIT = 150;
@@ -53,26 +68,15 @@ export class RegistryService {
     }
   }
 
-  async listRegistryItems(options?: {
-    kind?: string;
-    query?: string;
-    limit?: number;
-    offset?: number;
-  }): Promise<{
-    total: number;
-    limit: number;
-    offset: number;
-    hasMore: boolean;
-    nextOffset?: number;
-    availableKinds: string[];
-    items: RegistryCatalogItem[];
-  }> {
+  async listRegistryItems(
+    options?: ListRegistryItemsParams,
+  ): ListRegistryItemsResult {
     const snapshot = await this.createSnapshot();
     const catalog = this.buildCatalog(snapshot);
-    const filteredCatalog = this.filterCatalog(catalog, options);
-    const page = this.paginateItems(filteredCatalog, options);
+    const filteredCatalog = this.filterCatalog({ catalog, options });
+    const page = this.paginateItems({ items: filteredCatalog, options });
 
-    return {
+    const result: Awaited<ListRegistryItemsResult> = {
       total: filteredCatalog.length,
       limit: page.limit,
       offset: page.offset,
@@ -81,28 +85,19 @@ export class RegistryService {
       availableKinds: this.getAvailableKinds(catalog),
       items: page.items,
     };
+
+    return result;
   }
 
-  async searchRegistryItems(options: {
-    query: string;
-    kind?: string;
-    limit?: number;
-    offset?: number;
-  }): Promise<{
-    query: string;
-    total: number;
-    limit: number;
-    offset: number;
-    hasMore: boolean;
-    nextOffset?: number;
-    availableKinds: string[];
-    items: RegistryCatalogItem[];
-  }> {
+  async searchRegistryItems(
+    options: SearchRegistryItemsParams,
+  ): SearchRegistryItemsResult {
     const snapshot = await this.createSnapshot();
     const catalog = this.buildCatalog(snapshot);
     const query = options.query.trim();
-    const filteredCatalog = this.filterCatalog(catalog, {
-      kind: options.kind,
+    const filteredCatalog = this.filterCatalog({
+      catalog,
+      options: { kind: options.kind },
     });
 
     const rankedItems = filteredCatalog
@@ -119,7 +114,7 @@ export class RegistryService {
         return left.item.name.localeCompare(right.item.name);
       })
       .map((entry) => entry.item);
-    const page = this.paginateItems(rankedItems, options);
+    const page = this.paginateItems({ items: rankedItems, options });
 
     return {
       query,
@@ -135,11 +130,7 @@ export class RegistryService {
 
   async getRegistryItem(
     name: string,
-    options?: {
-      includeSource?: boolean;
-      includeExamples?: boolean;
-      includeRelated?: boolean;
-    },
+    options?: GetRegistryItemOptions,
   ): Promise<RegistryCatalogItemDetail> {
     const snapshot = await this.createSnapshot();
     const catalog = this.buildCatalog(snapshot);
@@ -249,13 +240,10 @@ export class RegistryService {
     }));
   }
 
-  private filterCatalog(
-    catalog: RegistryCatalogItem[],
-    options?: {
-      kind?: string;
-      query?: string;
-    },
-  ): RegistryCatalogItem[] {
+  private filterCatalog({
+    catalog,
+    options,
+  }: FilterCatalogParams): RegistryCatalogItem[] {
     const normalizedKind = options?.kind?.trim().toLowerCase();
     const normalizedQuery = options?.query?.trim().toLowerCase();
     const queryTerms = this.tokenizeSearchWords(options?.query ?? "");
@@ -435,32 +423,25 @@ export class RegistryService {
     return Math.max(Math.trunc(offset), 0);
   }
 
-  private paginateItems<T>(
-    items: T[],
-    options?: {
-      limit?: number;
-      offset?: number;
-    },
-  ): {
-    limit: number;
-    offset: number;
-    hasMore: boolean;
-    nextOffset?: number;
-    items: T[];
-  } {
+  private paginateItems<T>({
+    items,
+    options,
+  }: PaginateItemsParams<T>): PaginateItemsResult<T> {
     const limit = this.normalizeLimit(options?.limit);
     const offset = this.normalizeOffset(options?.offset);
     const paginatedItems = items.slice(offset, offset + limit);
     const nextOffset = offset + paginatedItems.length;
     const hasMore = nextOffset < items.length;
 
-    return {
+    const result: PaginateItemsResult<T> = {
       limit,
       offset,
       hasMore,
       nextOffset: hasMore ? nextOffset : undefined,
       items: paginatedItems,
     };
+
+    return result;
   }
 
   private getEntryDependencies(entries: RegistryEntry[], name: string): string[] {
@@ -484,8 +465,8 @@ export class RegistryService {
       item.kind === "component"
         ? snapshot.exampleNamesByComponent.get(item.name) ?? []
         : this.extractRegistryDependencyNames(
-            this.getEntryRegistryDependencies(snapshot.entries, item.name),
-          );
+          this.getEntryRegistryDependencies(snapshot.entries, item.name),
+        );
 
     return relatedNames.flatMap((relatedName) => {
       const relatedItem = catalogByName.get(relatedName);
@@ -506,16 +487,13 @@ export class RegistryService {
   }
 
   private tokenizeSearchValue(value: string): string[] {
-    const normalizedValue = value.trim().toLowerCase();
+    const formatted = formatSearchString(value);
 
-    if (!normalizedValue) {
+    if (!formatted) {
       return [];
     }
 
-    const rawTokens = normalizedValue
-      .split(/[^a-z0-9]+/)
-      .map((token) => token.trim())
-      .filter(Boolean);
+    const { normalizedValue, rawTokens } = formatted;
 
     const normalizedTokens = rawTokens.flatMap((token) => {
       const singularToken = this.toSingularToken(token);
@@ -529,19 +507,15 @@ export class RegistryService {
   }
 
   private tokenizeSearchWords(value: string): string[] {
-    const normalizedValue = value.trim().toLowerCase();
+    const formatted = formatSearchString(value);
 
-    if (!normalizedValue) {
+    if (!formatted) {
       return [];
     }
 
     return [
       ...new Set(
-        normalizedValue
-          .split(/[^a-z0-9]+/)
-          .map((token) => token.trim())
-          .filter(Boolean)
-          .map((token) => this.toSingularToken(token) ?? token),
+        formatted.rawTokens.map((token) => this.toSingularToken(token) ?? token),
       ),
     ];
   }
@@ -627,12 +601,7 @@ export class RegistryService {
     return source;
   }
 
-  private buildFilesSource(
-    files: Array<{
-      content: string;
-      path?: string;
-    }>,
-  ): string | undefined {
+  private buildFilesSource(files: BuildFilesSourceOptions): string | undefined {
     const source = files
       .map((file) => {
         const trimmedContent = file.content.trim();

--- a/src/services/registry-service.ts
+++ b/src/services/registry-service.ts
@@ -15,8 +15,8 @@ import {
 import {
   formatComponentName,
   formatDisplayName,
-  formatSearchString,
 } from "../utils/formatters.js";
+import { formatSearchString } from "../utils/search.js";
 import type {
   BuildFilesSourceOptions,
   FilterCatalogParams,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,0 +1,74 @@
+import type { RegistryCatalogItem } from "../domain/registry.js";
+
+export type PaginatedResult<T> = {
+    total: number;
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+    nextOffset?: number;
+    items: T[];
+};
+
+export type ListRegistryItemsParams = {
+    kind?: string;
+    query?: string;
+    limit?: number;
+    offset?: number;
+};
+
+export type ListRegistryItemsResult = Promise<{
+    availableKinds: string[];
+} & PaginatedResult<RegistryCatalogItem>>;
+
+export type SearchRegistryItemsParams = {
+    query: string;
+    kind?: string;
+    limit?: number;
+    offset?: number;
+};
+
+export type SearchRegistryItemsResult = Promise<{
+    query: string;
+    availableKinds: string[];
+} & PaginatedResult<RegistryCatalogItem>>;
+
+export type GetRegistryItemOption =
+    | "includeSource"
+    | "includeExamples"
+    | "includeRelated";
+
+export type GetRegistryItemOptions = Partial<
+    Record<GetRegistryItemOption, boolean>
+>;
+
+export type GetRegistryItemParams = {
+    name: string;
+    options?: GetRegistryItemOptions;
+};
+
+
+export type FilterCatalogOptions = Partial<{
+    kind: string;
+    query: string;
+}>;
+
+export type FilterCatalogParams = {
+    catalog: RegistryCatalogItem[];
+    options?: FilterCatalogOptions;
+};
+
+export type PaginateItemsOptions<T> = Partial<
+    Pick<PaginatedResult<T>, "limit" | "offset">
+>;
+
+export type PaginateItemsParams<T> = {
+    items: T[];
+    options?: PaginateItemsOptions<T>;
+};
+
+export type PaginateItemsResult<T> = Omit<PaginatedResult<T>, "total">;
+
+export type BuildFilesSourceOptions = Array<{
+    content: string;
+    path?: string;
+}>;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,25 +1,5 @@
 // Helper function to format component names
 
-export type SearchStringSplit = {
-  normalizedValue: string;
-  rawTokens: string[];
-};
-
-export function formatSearchString(value: string): SearchStringSplit | undefined {
-  const normalizedValue = value.trim().toLowerCase();
-
-  if (!normalizedValue) {
-    return undefined;
-  }
-
-  const rawTokens = normalizedValue
-    .split(/[^a-z0-9]+/)
-    .map((token) => token.trim())
-    .filter(Boolean);
-
-  return { normalizedValue, rawTokens };
-}
-
 export function formatComponentName(name: string): string {
   return name
     .split("-")
@@ -37,6 +17,3 @@ export function formatDisplayName(name: string): string {
     })
     .join(" ");
 }
-
-
-

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,4 +1,25 @@
 // Helper function to format component names
+
+export type SearchStringSplit = {
+  normalizedValue: string;
+  rawTokens: string[];
+};
+
+export function formatSearchString(value: string): SearchStringSplit | undefined {
+  const normalizedValue = value.trim().toLowerCase();
+
+  if (!normalizedValue) {
+    return undefined;
+  }
+
+  const rawTokens = normalizedValue
+    .split(/[^a-z0-9]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+  return { normalizedValue, rawTokens };
+}
+
 export function formatComponentName(name: string): string {
   return name
     .split("-")
@@ -16,3 +37,6 @@ export function formatDisplayName(name: string): string {
     })
     .join(" ");
 }
+
+
+

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,19 @@
+export type SearchStringSplit = {
+  normalizedValue: string;
+  rawTokens: string[];
+};
+
+export function formatSearchString(value: string): SearchStringSplit | undefined {
+  const normalizedValue = value.trim().toLowerCase();
+
+  if (!normalizedValue) {
+    return undefined;
+  }
+
+  const rawTokens = normalizedValue
+    .split(/[^a-z0-9]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+  return { normalizedValue, rawTokens };
+}


### PR DESCRIPTION
> These changes are as unnecessary as possible. I just wanted the code to look nice, sorry.

Features:

- Introduced new types for pagination and filtering in `types.ts`.
- Refactored `listRegistryItems` and `searchRegistryItems` methods to utilize new type definitions.
- Updated `filterCatalog` and `paginateItems` methods for better parameter handling.
- Added `formatSearchString` utility function to streamline search string processing.
- Created a base type for `RegistryCatalogItem` to reduce redundancy in example definitions.